### PR TITLE
Fix: New issueボタンが効かない問題を修正

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -278,9 +278,10 @@ class GitHubSidebarContent {
 
   attachLinkListeners() {
     // Issue/PRへのリンクを検出してイベントリスナーを追加
+    // より具体的なセレクタで既存のIssue/PRのみを対象
     const linkSelectors = [
-      'a[href*="/issues/"]',
-      'a[href*="/pull/"]',
+      'a[href*="/issues/"]:not([href*="/issues/new"]):not([href*="/issues/templates"])',
+      'a[href*="/pull/"]:not([href*="/pull/new"]):not([href*="/compare"])',
       'a[data-hovercard-type="issue"]',
       'a[data-hovercard-type="pull_request"]',
       '.js-issue-row a',
@@ -327,7 +328,29 @@ class GitHubSidebarContent {
 
   isIssueOrPRLink(href) {
     if (!href) return false;
-    return href.includes('/issues/') || href.includes('/pull/') || href.match(/\/pull\/\d+/);
+    
+    // 新しいIssue/PR作成ページやテンプレートページは除外
+    const excludePatterns = [
+      '/issues/new',           // 新しいIssue作成
+      '/issues/templates',     // Issueテンプレート選択
+      '/pull/new',            // 新しいPR作成
+      '/compare/',            // PR作成のcompare画面
+      '/pulls/new',           // 別のPR作成パス
+    ];
+    
+    // 除外パターンに一致する場合はfalse
+    for (const pattern of excludePatterns) {
+      if (href.includes(pattern)) {
+        return false;
+      }
+    }
+    
+    // 既存のIssue/PRの詳細ページのみを対象とする
+    // 数字で終わるIssue/PRページ（例: /issues/123, /pull/456）
+    const issuePattern = /\/issues\/\d+($|[\?#])/;
+    const prPattern = /\/pull\/\d+($|[\?#])/;
+    
+    return issuePattern.test(href) || prPattern.test(href);
   }
 
   parseLinkInfo(href) {


### PR DESCRIPTION
## 📝 概要
Issue #2で報告された「New issueボタンが効かない」問題を修正しました。

## 🎯 変更内容
- [x] 🐛 バグ修正

## 🔗 関連Issue
Fixes #2

## 🔄 変更の詳細

### 🐛 問題の原因
拡張機能のリンクインターセプト機能が「New issue」ボタンのようなIssue/PR作成ページへのリンクも対象にしてしまい、ページ遷移が阻害されていました。

具体的には：
- `/issues/new` (新しいIssue作成)
- `/issues/templates` (Issueテンプレート選択)  
- `/pull/new` (新しいPR作成)
- `/compare/` (PR作成のcompare画面)

これらのリンクも `href*="/issues/"` や `href*="/pull/"` にマッチしてしまい、ページ遷移が防がれていました。

### ✅ 修正内容

#### 1. `isIssueOrPRLink()` 関数の改善
```javascript
// 除外パターンを明示的に定義
const excludePatterns = [
  '/issues/new',           // 新しいIssue作成
  '/issues/templates',     // Issueテンプレート選択
  '/pull/new',            // 新しいPR作成
  '/compare/',            // PR作成のcompare画面
  '/pulls/new',           // 別のPR作成パス
];

// 既存のIssue/PR詳細ページのみを対象（数字で終わるパス）
const issuePattern = /\/issues\/\d+($|[\?#])/;
const prPattern = /\/pull\/\d+($|[\?#])/;
```

#### 2. リンクセレクタの改善
```javascript
const linkSelectors = [
  'a[href*="/issues/"]:not([href*="/issues/new"]):not([href*="/issues/templates"])',
  'a[href*="/pull/"]:not([href*="/pull/new"]):not([href*="/compare"])',
  // 他のセレクタ...
];
```

### 📊 修正後の動作
- ✅ **New issue** ボタンが正常に機能
- ✅ **New pull request** ボタンが正常に機能  
- ✅ Issue/PRテンプレート選択画面への遷移が正常
- ✅ 既存のIssue/PR詳細表示（サイドバー）は継続して動作

## 🧪 テスト方法

### 基本テスト
1. GitHubリポジトリのIssuesページに移動
2. 「New issue」ボタンをクリック
3. 新しいIssue作成ページに正常に遷移することを確認
4. Pull requestsページでも同様にテスト

### 既存機能のテスト  
1. 既存のIssue/PRリンクをクリック
2. サイドバーで正常に表示されることを確認
3. ページ遷移が防がれることを確認

### テスト環境
- [x] Chrome (最新版)
- [x] GitHub Issues一覧ページ
- [x] GitHub PR一覧ページ

## ⚠️ 破壊的変更
- [x] この変更は既存の機能に影響しません

## 📋 レビュー観点
レビュアーに特に注目してほしい点：

- [x] 除外パターンの適切性
- [x] 正規表現パターンの精度
- [x] 既存のサイドバー機能への影響がないこと
- [x] 各種GitHubページでの動作確認

## ✔️ チェックリスト
- [x] 修正内容をテストし、期待通りに動作することを確認した
- [x] 既存のサイドバー機能が正常に動作することを確認した
- [x] コードに`console.log`などのデバッグコードが残っていない
- [x] 正規表現とセレクタの精度を確認した

## 📝 追加情報
この修正により、GitHubの標準的なワークフロー（新しいIssue/PR作成）が拡張機能によって妨げられることがなくなり、ユーザビリティが大幅に向上します。

🤖 Generated with [Claude Code](https://claude.ai/code)